### PR TITLE
Refactor: Fortalacer la Entidad User

### DIFF
--- a/CookingSharp/CookingSharp.Application/Services/UserService.cs
+++ b/CookingSharp/CookingSharp.Application/Services/UserService.cs
@@ -1,12 +1,14 @@
-﻿using CookingSharp.Application.Services.Contracts;
+﻿using CookingSharp.Application.DTOs;
 using CookingSharp.Domain;
-using CookingSharp.Application.DTOs;
+using CookingSharp.Application.Services.Contracts;
 
 namespace CookingSharp.Application.Services
 {
+    /// <summary>
+    /// Proporciona la lógica de negocio para gestionar los usuarios.
+    /// </summary>
     public class UserService
     {
-
         private readonly IUserRepository _userRepository;
 
         public UserService(IUserRepository userRepository)
@@ -14,11 +16,15 @@ namespace CookingSharp.Application.Services
             _userRepository = userRepository;
         }
 
-
+        /// <summary>
+        /// Obtiene un usuario por su identificador único.
+        /// </summary>
+        /// <param name="id">El ID del usuario a buscar.</param>
+        /// <returns>Un DTO de respuesta del usuario si se encuentra; de lo contrario, null.</returns>
         public async Task<UserResponseDTO?> GetAsync(int id)
         {
             var user = await _userRepository.GetByIdAsync(id);
-            if (user == null)
+            if (user is null)
             {
                 return null;
             }
@@ -31,6 +37,10 @@ namespace CookingSharp.Application.Services
             };
         }
 
+        /// <summary>
+        /// Obtiene todos los usuarios existentes.
+        /// </summary>
+        /// <returns>Una colección de DTOs de respuesta de todos los usuarios.</returns>
         public async Task<IEnumerable<UserResponseDTO>> GetAllAsync()
         {
             var users = await _userRepository.GetAllAsync();
@@ -43,6 +53,11 @@ namespace CookingSharp.Application.Services
             });
         }
 
+        /// <summary>
+        /// Añade un nuevo usuario al sistema.
+        /// </summary>
+        /// <param name="dto">El DTO con la información del nuevo usuario.</param>
+        /// <returns>El DTO de respuesta del usuario recién creado.</returns>
         public async Task<UserResponseDTO> AddAsync(UserDTO dto)
         {
             if (await _userRepository.ExistsWithEmailAsync(dto.Email))
@@ -54,20 +69,23 @@ namespace CookingSharp.Application.Services
 
             var addedUser = await _userRepository.AddAsync(user);
 
-            var responseDto = new UserResponseDTO
+            return new UserResponseDTO
             {
                 Id = addedUser.Id,
                 Name = addedUser.Name,
                 Surname = addedUser.Surname,
                 Email = addedUser.Email
             };
-            return responseDto;
         }
 
+        /// <summary>
+        /// Actualiza la información del perfil de un usuario existente.
+        /// </summary>
+        /// <param name="dto">El DTO con los datos actualizados del perfil del usuario.</param>
         public async Task UpdateAsync(UserResponseDTO dto)
         {
             var existingUser = await _userRepository.GetByIdAsync(dto.Id);
-            if (existingUser == null)
+            if (existingUser is null)
             {
                 throw new KeyNotFoundException($"User with ID {dto.Id} not found.");
             }
@@ -75,12 +93,17 @@ namespace CookingSharp.Application.Services
             {
                 throw new ArgumentException("User with the same email already exists.");
             }
-            existingUser.Name = dto.Name;
-            existingUser.Surname = dto.Surname;
-            existingUser.Email = dto.Email;
+
+            existingUser.UpdateProfile(dto.Name, dto.Surname, dto.Email);
+
             await _userRepository.UpdateAsync(existingUser);
         }
 
+        /// <summary>
+        /// Elimina un usuario por su identificador único.
+        /// </summary>
+        /// <param name="id">El ID del usuario a eliminar.</param>
+        /// <returns>Verdadero si la eliminación fue exitosa, falso en caso contrario.</returns>
         public async Task<bool> DeleteAsync(int id)
         {
             return await _userRepository.DeleteAsync(id);

--- a/CookingSharp/CookingSharp.Domain/User.cs
+++ b/CookingSharp/CookingSharp.Domain/User.cs
@@ -1,16 +1,31 @@
 ﻿namespace CookingSharp.Domain
 {
+    /// <summary>
+    /// Representa un usuario en el dominio del negocio.
+    /// </summary>
     public class User
     {
         public int Id { get; set; }
-        public string Name { get; set; }
-        public string Surname { get; set; }
-        public string Email { get; set; }
-        public string Password { get; set; }
+        public string Name { get; private set; }
+        public string Surname { get; private set; }
+        public string Email { get; private set; }
+        public string Password { get; private set; }
 
+        /// <summary>
+        /// Constructor para crear una nueva instancia de Usuario.
+        /// </summary>
         public User(int id, string name, string surname, string email, string password)
         {
+            Id = id;
+            UpdateProfile(name, surname, email);
+            ChangePassword(password);
+        }
 
+        /// <summary>
+        /// Actualiza la información del perfil del usuario, aplicando las reglas de validación.
+        /// </summary>
+        public void UpdateProfile(string name, string surname, string email)
+        {
             if (string.IsNullOrWhiteSpace(name))
             {
                 throw new ArgumentException("El nombre no puede ser nulo o vacío.", nameof(name));
@@ -23,18 +38,27 @@
             {
                 throw new ArgumentException("El correo electrónico no puede ser nulo o vacío.", nameof(email));
             }
-            if (string.IsNullOrWhiteSpace(password))
-            {
-                throw new ArgumentException("La contraseña no puede ser nula o vacía.", nameof(password));
-            }
-            Id = id;
+
             Name = name;
             Surname = surname;
             Email = email;
-            Password = password;
-
         }
 
+        /// <summary>
+        /// Cambia la contraseña del usuario, aplicando las reglas de validación de seguridad.
+        /// </summary>
+        public void ChangePassword(string newPassword)
+        {
+            if (string.IsNullOrWhiteSpace(newPassword))
+            {
+                throw new ArgumentException("La contraseña no puede ser nula o vacía.", nameof(newPassword));
+            }
+            if (newPassword.Length < 8)
+            {
+                throw new ArgumentException("La contraseña debe tener al menos 8 caracteres.", nameof(newPassword));
+            } //TO DO: sumarle requisitos, quizás con exp reg
 
+            Password = newPassword;
+        }
     }
 }

--- a/CookingSharp/CookingSharp.Infrastructure/Persistence/Repositories/InMemoryUserRepository.cs
+++ b/CookingSharp/CookingSharp.Infrastructure/Persistence/Repositories/InMemoryUserRepository.cs
@@ -3,28 +3,34 @@ using CookingSharp.Domain;
 
 namespace CookingSharp.Infrastructure.Persistence.Repositories
 {
+    /// <summary>
+    /// Implementación en memoria del repositorio de usuarios, utilizada para desarrollo y pruebas.
+    /// </summary>
     public class InMemoryUserRepository : IUserRepository
     {
         private static readonly List<User> _users = new List<User>
         {
-            new User(1, "Emiliano", "Luhmann", "emyluhmann@gmail.com", "123"),
-            new User(2, "Nicolas", "Pedemonte", "NicoPedi@gmail.com", "123"),
-            new User(3, "Luca", "Trincavelli", "LucaTricavelli@gmail.com", "123")
+            new User(1, "Emiliano", "Luhmann", "emyluhmann@gmail.com", "12345678"),
+            new User(2, "Nicolas", "Pedemonte", "NicoPedi@gmail.com", "12345678"),
+            new User(3, "Luca", "Trincavelli", "LucaTricavelli@gmail.com", "12345678")
         };
 
-        private static int _nextId = _users.Any() ? _users.Max(c => c.Id) + 1 : 1;
+        private static int _nextId = _users.Any() ? _users.Max(u => u.Id) + 1 : 1;
 
+        /// <inheritdoc />
         public Task<User?> GetByIdAsync(int id)
-        { 
-            var user = _users.Find(u => u.Id == id); // Check if FirstOrDefault is useful here
+        {
+            var user = _users.Find(u => u.Id == id);
             return Task.FromResult(user);
         }
 
+        /// <inheritdoc />
         public Task<IEnumerable<User>> GetAllAsync()
         {
             return Task.FromResult(_users.AsEnumerable());
         }
 
+        /// <inheritdoc />
         public Task<User> AddAsync(User user)
         {
             user.Id = _nextId++;
@@ -32,23 +38,25 @@ namespace CookingSharp.Infrastructure.Persistence.Repositories
             return Task.FromResult(user);
         }
 
+        /// <inheritdoc />
         public Task UpdateAsync(User user)
         {
             var existingUser = _users.Find(u => u.Id == user.Id);
-            if (existingUser != null)
+            if (existingUser is not null)
             {
-                existingUser.Name = user.Name;
-                existingUser.Email = user.Email;
-                existingUser.Surname = user.Surname;
-                existingUser.Password = user.Password;
+                // El repositorio, al simular la base de datos, actualiza todo el estado de la entidad
+                // a través de sus métodos públicos.
+                existingUser.UpdateProfile(user.Name, user.Surname, user.Email);
+                existingUser.ChangePassword(user.Password);
             }
             return Task.CompletedTask;
         }
 
+        /// <inheritdoc />
         public Task<bool> DeleteAsync(int id)
         {
-            var userToDelete = _users.Find(c => c.Id == id);
-            if (userToDelete == null)
+            var userToDelete = _users.Find(u => u.Id == id);
+            if (userToDelete is null)
             {
                 return Task.FromResult(false);
             }
@@ -56,14 +64,15 @@ namespace CookingSharp.Infrastructure.Persistence.Repositories
             return Task.FromResult(true);
         }
 
+        /// <inheritdoc />
         public Task<bool> ExistsWithEmailAsync(string mail, int? excludeId = null)
         {
             var query = _users.AsQueryable();
             if (excludeId.HasValue)
             {
-                query = query.Where(c => c.Id != excludeId.Value);
+                query = query.Where(u => u.Id != excludeId.Value);
             }
-            bool exists = query.Any(c => c.Email.Equals(mail, StringComparison.OrdinalIgnoreCase));
+            bool exists = query.Any(u => u.Email.Equals(mail, StringComparison.OrdinalIgnoreCase));
             return Task.FromResult(exists);
         }
     }


### PR DESCRIPTION
### Descripción

Este PR implementa la refactorización de la entidad `User` para que sea la única responsable de su estado y validaciones, completando el fortalecimiento de la capa de Dominio.

Se han hecho privados los setters y se han introducido los métodos `UpdateProfile` y `ChangePassword` para separar las responsabilidades de modificación de datos. Las capas de Aplicación e Infraestructura han sido actualizadas para respetar este nuevo contrato.

---

### Issue Relacionado

Closes #22 

---

### Definición de 'Hecho' (Checklist)

- [x] El código compila sin errores.
- [x] La documentación XML de los métodos `UpdateProfile` y `ChangePassword` ha sido añadida.
- [x] La entidad `User` ya no puede ser modificada externamente excepto a través de sus métodos públicos designados.

---

### Cómo Verificar

1.  Compilar la solución (`Rebuild Solution`). Debe compilar sin errores.
2.  Ejecutar la solución en modo de inicio múltiple (`WebAPI` y `WindowsForms`).
3.  Verificar que ambas aplicaciones se inician y que WinForms carga los datos de los usuarios.
4.  Probar la funcionalidad de **actualizar un usuario** desde WinForms (cambiar nombre, apellido o email) y confirmar que el cambio se refleja correctamente en la API (vía Swagger).